### PR TITLE
linking to criteria used to determine Yes or No

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,8 +180,8 @@ margin-bottom: -10px;
 <li>Edward â€œEdâ€ Washington II YES
 </ul>
 <div id="footer">
-Built by <a href="http://www.twitter.com/dansinker">@dansinker</a> from data compiled by the <a href="http://voteforjudges.org/">Committee to Elect Qualified Judges</a>.
-</div>
+Built by <a href="http://www.twitter.com/dansinker">@dansinker</a> from data compiled by the <a href="http://voteforjudges.org/">Committee to Elect Qualified Judges</a>. The criteria they used is summarized in 
+																<a href="http://www.chicagocouncil.org/wp-content/uploads/evaluations-for-November-2016-ballot2.pdf">The Chicago Council of Lawyers Evaluation Report</a></div>
 
 <script type="text/javascript">
 $('li:even').addClass('even');


### PR DESCRIPTION
The report leads off with a bullet list of how the Chicago Council of Lawyers made their recommendations. It's a couple clicks into their site, so it wold be great to link more directly to it. Or, if linking to a PDF is no good, you could add a second page that provides the criteria list and a link to the full report.